### PR TITLE
Fix tracking dimension handling and cleanup

### DIFF
--- a/arcos4py/_arcos4py.py
+++ b/arcos4py/_arcos4py.py
@@ -123,10 +123,16 @@ class ARCOS:
     def _check_col(self):
         """Checks that self.cols contains all required columns."""
         columns = self.data.columns
-        input_columns = [self.frame_column, self.obj_id_column, self.obj_id_column, self.measurement_column]
+        input_columns = [
+            self.frame_column,
+            self.obj_id_column,
+            self.measurement_column,
+        ]
         input_columns = [col for col in input_columns if col is not None]
         if not all(item in columns for item in input_columns):
-            raise ValueError(f"Columns {input_columns} do not match with column in dataframe.")
+            raise ValueError(
+                f"Columns {input_columns} do not match with column in dataframe."
+            )
 
     def interpolate_measurements(self) -> pd.DataFrame:
         """Interpolates NaN's in place in measurement column.


### PR DESCRIPTION
## Summary
- fix duplication of ID column checks in `ARCOS._check_col`
- validate dims correctly in `ImageTracker.track`
- respect specified time dimension in `track_events_image`
- remove leftover debug code from linker

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68755b2ec1e0832487fc8ea8d5a335c7