### PR TITLE
Fix inconsistent parameter docs

### DIFF
--- a/arcos4py/tools/_binarize_detrend.py
+++ b/arcos4py/tools/_binarize_detrend.py
@@ -33,10 +33,9 @@ class detrender:
         smooth_k (int): Representing the size of the short-term median smoothing filter.
         bias_k (int): Representing the size of the long-term de-trending median filter.
         peak_threshold (float): Threshold for rescaling of the de-trended signal.
-        polynomial_degree (int): Sets the degree of the polynomial for lm fitting..
+        polynomial_degree (int): Sets the degree of the polynomial for lm fitting.
         bias_method (str): Indicating de-trending method, one of ['runmed', 'lm', 'none'].
-        n_jobs (int): Number of paralell workers to spawn, -1 uses all available cpus.biasMet (str):
-            Indicating de-trending method, one of ['runmed', 'lm', 'none'].
+        n_jobs (int): Number of parallel workers to spawn, -1 uses all available CPUs.
     """
 
     def __init__(
@@ -53,7 +52,7 @@ class detrender:
 
         Arguments:
             smooth_k (int): Representing the size of the short-term median smoothing filter.
-            bias_k (int): Representing the size of the long-term de-trending median filter.ian filter.
+            bias_k (int): Representing the size of the long-term de-trending median filter.
             peak_threshold (float): Threshold for rescaling of the de-trended signal.
             polynomial_degree (int): Sets the degree of the polynomial for lm fitting.
             bias_method (str): Indicating de-trending method, one of ['runmed', 'lm', 'none'].

--- a/arcos4py/tools/_detect_events.py
+++ b/arcos4py/tools/_detect_events.py
@@ -2085,7 +2085,7 @@ class detectCollev:
                 point to be considered as a core point. This includes the point itself.
                 Only used if clusteringMethod is 'hdbscan'. If None, minSamples =  minClsz.
             linkingMethod (str): The method used for linking. Default is 'nearest'.
-            n_jobs (int): Number of paralell workers to spawn, -1 uses all available cpus.
+            n_jobs (int): Number of parallel workers to spawn, -1 uses all available CPUs.
             predictor (bool | Callable): Whether or not to use a predictor. Default is False.
                 True uses the default predictor. A callable can be passed to use a custom predictor.
                 See default predictor method for details.

--- a/arcos4py/validation/_bootstrapping.py
+++ b/arcos4py/validation/_bootstrapping.py
@@ -317,15 +317,15 @@ def calculate_arcos_stats(
         binarization_threshold (float, optional): Threshold for binarizing measurements after detrending. Defaults to 0.1.
         polynomial_degree (int, optional): Polynomial degree used for detrending (used with biasMet='lm'). Defaults to 1.
         bias_method (str, optional): Bias method, can be 'none', 'runmed', 'lm'. Defaults to "runmed".
-        eps (float, optional): Epsilon used for culstering active entities. Defaults to 2.
-        eps_prev (int, optional): Epsilon used for linking together culsters across time. Defaults to None.
+        eps (float, optional): Epsilon used for clustering active entities. Defaults to 2.
+        eps_prev (int, optional): Epsilon used for linking together clusters across time. Defaults to None.
         min_clustersize (int, optional): Minimum cluster size. Defaults to 1.
         n_prev (int, optional): Number of previous frames to consider when tracking clusters. Defaults to 1.
         min_duration (int, optional): Minimum duration of detected event. Defaults to 1.
         min_total_size (int, optional): Minimum size, minimum size of detected event. Defaults to 1.
         stats_metric (list[str], optional): List of metrics to calculate. Defaults to ['duration', 'total_size'].
         show_progress (bool, optional): Show progress bar. Defaults to True.
-        parallel_processing (bool, optional): Use paralell processing, uses the joblib package. Defaults to True.
+        parallel_processing (bool, optional): Use parallel processing, uses the joblib package. Defaults to True.
         clid_column (str, optional): Name of the cluster id column. Defaults to 'clid'.
         **kwargs (Any): Additional keyword arguments. Includes deprecated parameters.
             - posCols: Deprecated. Use position_columns instead.

--- a/tests/test_resampling.py
+++ b/tests/test_resampling.py
@@ -7,7 +7,7 @@ from arcos4py.validation._resampling import (
     _get_xy_change,
     resample_data,
     shift_timepoints_per_trajectory,
-    shuffle_activity_bocks_per_trajectory,
+    shuffle_activity_blocks_per_trajectory,
     shuffle_coordinates_per_timepoint,
     shuffle_timepoints,
     shuffle_tracks,
@@ -47,7 +47,7 @@ def test_shuffle_tracks():
     assert df_new['y'].to_list() != [2, 3, 4, 5, 6, 7]
 
     # Assert that x and y stay in the correct pairs but with relative values
-    # according to the cummulative change of the original track
+    # according to the cumulative change of the original track
     assert df_new.loc[df_new['track_id'] == 1, ['x', 'y']].to_numpy().tolist() == [[4, 5], [5, 6], [6, 7]]
     assert df_new.loc[df_new['track_id'] == 2, ['x', 'y']].to_numpy().tolist() == [[1, 2], [3, 4], [5, 6]]
 
@@ -97,7 +97,7 @@ def test_shuffle_activity_blocks_per_trajectory():
     test_df.sort_values(by=['time', 'track_id'], inplace=True)
 
     # Test the function with a specific seed
-    df_new = shuffle_activity_bocks_per_trajectory(
+    df_new = shuffle_activity_blocks_per_trajectory(
         test_df, 'track_id', 'time', 'activity', seed=42, alternating_blocks=True
     )
 


### PR DESCRIPTION
## Summary
- correct typos in internal docstrings
- ensure warnings mention parallel processing correctly
- fix comments referencing cumulative change

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a4107683883248920dc137dae2968